### PR TITLE
parameterize container demands and remove version check on R

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # Version History
 
+## 1.0.15 / 2022-06-13
+
+- Parameterized pipeline container demands
+
 ## 1.0.14 / 2022-03-22
 
 - Changed agent used in pipeline

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PI Web API R Sample
 
-**Version:** 1.0.14
+**Version:** 1.0.15
 
 [![Build Status](https://dev.azure.com/osieng/engineering/_apis/build/status/product-readiness/PI-System/osisoft.sample-pi_web_api-common_actions-r?repoName=osisoft%2Fsample-pi_web_api-common_actions-r&branchName=main)](https://dev.azure.com/osieng/engineering/_build/latest?definitionId=2664&repoName=osisoft%2Fsample-pi_web_api-common_actions-r&branchName=main)
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,7 +39,7 @@ variables:
 
 parameters:
   - name: containerDemands
-    default: R -gVersion 4.1.3
+    default: R -gtVersion 4.1.3
 
 jobs:
   - job: Tests

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,12 +37,15 @@ variables:
   - name: analysisProject
     value: PIWebAPI_R
 
+parameters:
+  - name: containerDemands
+    default: R
+
 jobs:
   - job: Tests
     pool:
       name: 00-OSIManaged-Build
-      demands: 
-      - R -equals 4.1.3
+      demands: ${{ parameters.containerDemands }}
     steps:
       - template: '/miscellaneous/build_templates/config.yml@templates'
         parameters:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,7 +39,7 @@ variables:
 
 parameters:
   - name: containerDemands
-    default: R
+    default: R -gVersion 4.1.3
 
 jobs:
   - job: Tests


### PR DESCRIPTION
Parameterized the container demands, and removed the version number from the demand. [Demands can only demand the existence of a particular software, or an exact version match](https://docs.microsoft.com/en-us/azure/devops/pipelines/process/demands?view=azure-devops&tabs=yaml).
![image](https://user-images.githubusercontent.com/73293551/173435091-fd857cb5-40a6-4168-ac03-6442e2219939.png)

Since there's no way to match on an R version of ^x.y.z, keeping this version specific will continue to fail over time as the container images are upgraded; I would not consider these valid failures, so I'd like to remove the version check entirely. If the container happens to have too old of an R version somehow, then it will fail the pipeline, and we can temporarily demand a specific (later) version through the ADO portal's pipeline parameters until the container images with older versions are all updated.